### PR TITLE
Update secret command to use loaded config

### DIFF
--- a/src/commands/secret/registerSecretCommand.mts
+++ b/src/commands/secret/registerSecretCommand.mts
@@ -1,34 +1,29 @@
 import { Command } from 'commander'
 import { logSuccess, logError } from '@/utils/index.mjs'
-import { ENVIRONMENT_OPTION } from '@/utils/options.mjs'
 import { secretAction } from './secretAction.mjs'
 import { type SecretOptions } from './types.mjs'
+import { loadConfigFromPrompt } from '@/config/loadConfigFromPrompt.mjs'
 
-type SecretCommandOptions = SecretOptions
+type SecretCommandOptions = Pick<SecretOptions, 'secretName' | 'secretValue'>
 
 export function registerSecretCommand(program: Command): void {
   program
     .command('secret')
     .description('Create or update a Google Cloud secret')
-    .requiredOption('-p, --project <project-id>', 'Google Cloud Project ID')
     .requiredOption(
       '-s, --secret-name <secret-name>',
       'Name of the secret (without environment prefix)'
     )
     .requiredOption('-v, --secret-value <secret-value>', 'Value of the secret')
-    .addOption(ENVIRONMENT_OPTION.makeOptionMandatory(true))
-    .requiredOption(
-      '-n, --environment-name <environment-name>',
-      'Environment name'
-    )
     .action(async (options: SecretCommandOptions) => {
       try {
+        const config = await loadConfigFromPrompt()
         await secretAction({
-          project: options.project,
+          project: config.selection.project,
           secretName: options.secretName,
           secretValue: options.secretValue,
-          environment: options.environment,
-          environmentName: options.environmentName,
+          environment: config.selection.environment,
+          environmentName: config.selection.environmentName,
         })
         logSuccess('Done!')
       } catch (error: unknown) {


### PR DESCRIPTION
Update the secret command to use the loaded configuration instead of CLI options.

---
<a href="https://cursor.com/background-agent?bcId=bc-0555cf4f-d298-4543-9374-9b85fcb277f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0555cf4f-d298-4543-9374-9b85fcb277f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

